### PR TITLE
add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: Perl
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '42 5 * * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        perl: [ '5.30', '5.36' ]
+        exclude:
+          - runner: windows-latest
+            perl: '5.36'
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( startsWith( matrix.runner, 'windows-' ) && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Modules
+      run: |
+        cpanm -v
+        cpanm --installdeps --notest .
+
+    - name: Show Errors on Windows
+      if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}
+      run: |
+         ls -l C:/Users/
+         ls -l C:/Users/RUNNER~1/
+         cat C:/Users/runneradmin/.cpanm/work/*/build.log
+
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Show Errors on OSX
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+      run: |
+         cat  /Users/runner/.cpanm/work/*/build.log
+
+    - name: Run tests
+      env:
+        AUTHOR_TESTING: 1
+        RELEASE_TESTING: 1
+      run: |
+        perl Makefile.PL
+        make
+        make test
+
+

--- a/ABOUT.pod
+++ b/ABOUT.pod
@@ -10,57 +10,81 @@ In your config.yml
 
     plugins:
       DoFile:
-        page_loc: "dofiles/pages"
+        controller_loc: 'dofiles/controllers'
+        controller_extension_list: ['.ctl','.do']
+        view_loc: 'dofiles/views'
+        view_extension_list: ['.view','.po']
         default_file: "index"
-        extension_list: ['.do','.view']
 
-Make sure you have created the directory used for page_loc
+Make sure you have created the directory used for the locations in your dancer application root.
 
 Within a route in dancer2:
 
-    my $result = dofile 'path/to/file'
+    my $result = controller 'path/to/file'
 
 You must not include the extension of the file as part of the path, as this will
 be added per the settings.
 
-Or a default route, with example handling of some return values:
+An example route in Dancer2, not using HTML::Obj2HTML (the controller returns the
+layout and tokens directly):
+
+    get 'dashboard' => sub {
+      my $self = shift;
+      my $result = controller 'dashboards/user-dashboard';
+      return template $result->{layout} => $result->{tokens};
+    }
+
+An example default route that will search for controllers (or views) based on the
+URI requested, and some handling of other controller return keys:
 
     prefix '/';
     any qr{.*} => sub {
       my $self = shift;
-      my $result = dofile undef;
+
+      my $result = controller undef;  # Not specifying the controller to use will use the URI to guess
+
+      # My controller might return all manner of different things; this is an example:
       if ($result && ref $result eq "HASH") {
-        if (defined $result->{status}) {
-          status $result->{status};
-        }
         if (defined $result->{url}) {
           if (defined $result->{redirect} && $result->{redirect} eq "forward") {
             return forward $result->{url};
           } else {
             return redirect $result->{url};
           }
-        } elsif (defined $result->{content}) {
-          return $result->{content};
         }
-      }
+        if (defined $result->{status}) {
+          status $result->{status};
+        }
+        if (defined $result->{template}) {
+          set layout => $result->{template};
+        }
+        if (defined $result->{headers}) {
+          headers %{$result->{headers}};
+        }
+        if (defined $result->{content}) {
+          return template $result->{content}, $result->{tokens};
+        }
+      };
     };
 
-When the 1st parameter to 'dofile' is undef it'll use the request URI to work
+
+When the 1st parameter to 'controller' is undef it'll use the request URI to work
 out what the file(s) to execute are.
 
 =head1 DESCRIPTION
 
 DoFile is a way of automatically pulling multiple perl files to execute as a way
 to simplify routing complexity in Dancer2 for very large applications. In
-particular it was designed to offload "as many as possible" URIs that related to
-some standard functionality through a default route, just by having files
-existing for the specific URI.
+particular it was designed to split out larger controllers into logical partitions
+based on heirarchy of files compared to what's being requested.
 
 The magic will look through your filesystem for files to 'do' (execute), and
-there may be several. The intent is to split out controller files and
-view files, and these may individually be rolled out or split out. In the
-default configuration the controller files are suffixed .do, and the view files
-.view
+there may be several.
+
+An added benefit of using DoFile is it's ability to execute multiple files per
+request, effectively allowing you to split controllers into sub-parts. For example,
+you might have a "DoFile" that is always executed for /some/uri, and another
+for POST or GET, and even another for the fact you hade /some too.
 
 =head2 File Search Ordering
 
@@ -74,10 +98,11 @@ Files are searched:
 
 =item * By extension
 
-The default extensions .do and .view are checked, unless defined in your
-config.yml. The intention here is that .do files contain controller code and
-don't typically return content, but may return redirects. After .do files have
-been executed, .view files are executed. These are expected to return content.
+The default extensions .ctl and .view are checked (.do and .po are legacy extensions),
+unless defined in your config.yml. The intention here is that .do files contain
+controller code and don't typically return content, but may return redirects. After
+.do files have been executed, .view files are executed. These are expected to return
+content.
 
 You can define as many extensions as you like. You could, for example have:
 C<['.init','.do','.view','.final']>
@@ -86,16 +111,17 @@ C<['.init','.do','.view','.final']>
 
 For each extension, first the "root" file C<file.ext> is tested, then a file
 that matches C<file-METHOD.ext> is tested (where METHOD is the HTTP request
-method for this request, .ext is the extension).
+method for this request, .ext is the extension). Finally C<file-ANY.ext> is
+checked.
 
 =item * Iterating up the directory tree
 
-If your call to C<path/to/file> results in a miss for C<path/to/file.do>, DoFile
-will then test for C<path/to.do> and finally C<path.do> before moving on to
-C<path/to/file-METHOD.do>
+If your call to C<path/to/file> results in a miss for C<path/to/file.ctl>, DoFile
+will then test for C<path/to.ctl> and finally C<path.ctl> before moving on to
+C<path/to/file-METHOD.ctl>
 
 Once DoFile has found one it will not transcend the directory tree any further.
-Therefore defining C<path/to/file.do> and C<path/to.do> will not result in
+Therefore defining C<path/to/file.ctl> and C<path/to.ctl> will not result in
 both being executed for the URI C<path/to/file> - only the first will be
 executed.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
     'warnings' => 0,
     'Dancer2' => 0,
     'JSON' => 0,
-    'Hash::Merge' => 0,
+    'Time::HiRes' => 0,
     'HTTP::Accept' => 0
   },
   TEST_REQUIRES => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,8 @@ WriteMakefile(
     'warnings' => 0,
     'Dancer2' => 0,
     'JSON' => 0,
-    'Hash::Merge' => 0
+    'Hash::Merge' => 0,
+    'HTTP::Accept' => 0
   },
   TEST_REQUIRES => {
     'Dancer2' => 0,

--- a/lib/Dancer2/Plugin/DoFile.pm
+++ b/lib/Dancer2/Plugin/DoFile.pm
@@ -439,57 +439,81 @@ In your config.yml
 
     plugins:
       DoFile:
-        page_loc: "dofiles/pages"
+        controller_loc: 'dofiles/controllers'
+        controller_extension_list: ['.ctl','.do']
+        view_loc: 'dofiles/views'
+        view_extension_list: ['.view','.po']
         default_file: "index"
-        extension_list: ['.do','.view']
 
-Make sure you have created the directory used for page_loc
+Make sure you have created the directory used for the locations in your dancer application root.
 
 Within a route in dancer2:
 
-    my $result = dofile 'path/to/file'
+    my $result = controller 'path/to/file'
 
 You must not include the extension of the file as part of the path, as this will
 be added per the settings.
 
-Or a default route, with example handling of some return values:
+An example route in Dancer2, not using HTML::Obj2HTML (the controller returns the
+layout and tokens directly):
+
+    get 'dashboard' => sub {
+      my $self = shift;
+      my $result = controller 'dashboards/user-dashboard';
+      return template $result->{layout} => $result->{tokens};
+    }
+
+An example default route that will search for controllers (or views) based on the
+URI requested, and some handling of other controller return keys:
 
     prefix '/';
     any qr{.*} => sub {
       my $self = shift;
-      my $result = dofile undef;
+
+      my $result = controller undef;  # Not specifying the controller to use will use the URI to guess
+
+      # My controller might return all manner of different things; this is an example:
       if ($result && ref $result eq "HASH") {
-        if (defined $result->{status}) {
-          status $result->{status};
-        }
         if (defined $result->{url}) {
           if (defined $result->{redirect} && $result->{redirect} eq "forward") {
             return forward $result->{url};
           } else {
             return redirect $result->{url};
           }
-        } elsif (defined $result->{content}) {
-          return $result->{content};
         }
-      }
+        if (defined $result->{status}) {
+          status $result->{status};
+        }
+        if (defined $result->{template}) {
+          set layout => $result->{template};
+        }
+        if (defined $result->{headers}) {
+          headers %{$result->{headers}};
+        }
+        if (defined $result->{content}) {
+          return template $result->{content}, $result->{tokens};
+        }
+      };
     };
 
-When the 1st parameter to 'dofile' is undef it'll use the request URI to work
+
+When the 1st parameter to 'controller' is undef it'll use the request URI to work
 out what the file(s) to execute are.
 
 =head1 DESCRIPTION
 
 DoFile is a way of automatically pulling multiple perl files to execute as a way
 to simplify routing complexity in Dancer2 for very large applications. In
-particular it was designed to offload "as many as possible" URIs that related to
-some standard functionality through a default route, just by having files
-existing for the specific URI.
+particular it was designed to split out larger controllers into logical partitions
+based on heirarchy of files compared to what's being requested.
 
 The magic will look through your filesystem for files to 'do' (execute), and
-there may be several. The intent is to split out controller files and
-view files, and these may individually be rolled out or split out. In the
-default configuration the controller files are suffixed .do, and the view files
-.view
+there may be several.
+
+An added benefit of using DoFile is it's ability to execute multiple files per
+request, effectively allowing you to split controllers into sub-parts. For example,
+you might have a "DoFile" that is always executed for /some/uri, and another
+for POST or GET, and even another for the fact you hade /some too.
 
 =head2 File Search Ordering
 
@@ -503,10 +527,11 @@ Files are searched:
 
 =item * By extension
 
-The default extensions .do and .view are checked, unless defined in your
-config.yml. The intention here is that .do files contain controller code and
-don't typically return content, but may return redirects. After .do files have
-been executed, .view files are executed. These are expected to return content.
+The default extensions .ctl and .view are checked (.do and .po are legacy extensions),
+unless defined in your config.yml. The intention here is that .do files contain
+controller code and don't typically return content, but may return redirects. After
+.do files have been executed, .view files are executed. These are expected to return
+content.
 
 You can define as many extensions as you like. You could, for example have:
 C<['.init','.do','.view','.final']>
@@ -515,16 +540,17 @@ C<['.init','.do','.view','.final']>
 
 For each extension, first the "root" file C<file.ext> is tested, then a file
 that matches C<file-METHOD.ext> is tested (where METHOD is the HTTP request
-method for this request, .ext is the extension).
+method for this request, .ext is the extension). Finally C<file-ANY.ext> is
+checked.
 
 =item * Iterating up the directory tree
 
-If your call to C<path/to/file> results in a miss for C<path/to/file.do>, DoFile
-will then test for C<path/to.do> and finally C<path.do> before moving on to
-C<path/to/file-METHOD.do>
+If your call to C<path/to/file> results in a miss for C<path/to/file.ctl>, DoFile
+will then test for C<path/to.ctl> and finally C<path.ctl> before moving on to
+C<path/to/file-METHOD.ctl>
 
 Once DoFile has found one it will not transcend the directory tree any further.
-Therefore defining C<path/to/file.do> and C<path/to.do> will not result in
+Therefore defining C<path/to/file.ctl> and C<path/to.ctl> will not result in
 both being executed for the URI C<path/to/file> - only the first will be
 executed.
 

--- a/lib/Dancer2/Plugin/DoFile.pm
+++ b/lib/Dancer2/Plugin/DoFile.pm
@@ -154,6 +154,7 @@ OUTER:
         $opts{stash} = $stash;
 
         if (defined $result && ref $result eq "HASH") {
+          $stash = $merger->merge($stash, $result);
           if (defined $result->{url} && !defined $result->{done}) {
             $path = $result->{url};
             next OUTER;
@@ -166,8 +167,6 @@ OUTER:
           } elsif (defined $result->{content} || $result->{url} || $result->{done}) {
             $stash->{dofiles}->{$cururl.$m.$ext}->{last} = 1;
             return $result;
-          } else {
-            $stash = $merger->merge($stash, $result);
           }
           # Move on to the next file
 
@@ -186,7 +185,14 @@ OUTER:
   }
 
   # If we got here we didn't find a controller. We should fail over to see if it's just a view on its own (effectively this module or the route acts as the controller)
-  return $plugin->view($arg, %opts);
+  $opts{stash} = $stash;
+  if ($stash->{view}) {
+    $opts{'controller_arg'} = $arg;
+    return $plugin->view($stash->{view}, %opts);
+  } else {
+    return $plugin->view($arg, %opts);
+  }
+
 }
 
 sub view {

--- a/lib/Dancer2/Plugin/DoFile.pm
+++ b/lib/Dancer2/Plugin/DoFile.pm
@@ -226,7 +226,7 @@ sub view {
 
   if (!$path) { $path = $plugin->default_file; }
   if (-d $pageroot."/$path") {
-    if ($path =~ /\/$/) {
+    if ($path !~ /\/$/) {
       $path .= "/".$plugin->default_file;
     } else {
       return {

--- a/lib/Dancer2/Plugin/DoFile.pm
+++ b/lib/Dancer2/Plugin/DoFile.pm
@@ -1,16 +1,16 @@
 package Dancer2::Plugin::DoFile;
-$Dancer2::Plugin::DoFile::VERSION = '0.13';
-# ABSTRACT: File-based MVC plugin for Dancer2
 
 use strict;
 use warnings;
 
+$Dancer2::Plugin::DoFile::VERSION = '0.14';
+# ABSTRACT: File-based MVC plugin for Dancer2
+
 use Dancer2::Plugin;
 
 use JSON;
-use Hash::Merge;
 use HTTP::Accept;
-use Time::HiRes;
+use Time::HiRes qw(time);
 
 # Not sure if this is necessary at this point, as the model
 # Should in general not be dynamically loaded...
@@ -65,9 +65,9 @@ plugin_keywords 'view';
 
 my %dofiles;
 my $acceptext = {
-  "" => "",
-  "text/html" => ".html",
-  "application/json" => ".json"
+  '' => '',
+  'text/html' => '.html',
+  'application/json' => '.json'
 };
 
 sub BUILD {
@@ -75,7 +75,7 @@ sub BUILD {
     my $settings = $self->config;
 
     $settings->{$_} and $self->$_( $settings->{$_} )
-      for qw/ page_loc default_file extension_list controller_loc controller_extension_list view_loc view_extension_list /;
+      for qw/ page_loc default_file extension_list controller_loc controller_extension_list view_loc view_extension_list timings /;
 }
 
 sub controller {
@@ -88,7 +88,7 @@ sub controller {
   my $method = $app->request->method;
   my $pageroot = $settings->{appdir};
   if ($pageroot !~ /\/$/) {
-    $pageroot .= "/";
+    $pageroot .= '/';
   }
   $pageroot .= $plugin->controller_loc;
 
@@ -99,12 +99,10 @@ sub controller {
   # This can lead to some interesting results if someone doesn't explicitly return undef when they want to fall through to the next file
   # as perl will return the last evaluated value, which would be intepretted as content according to the above rules
 
-  my $merger = Hash::Merge->new('RIGHT_PRECEDENT');
-
   my $stash = $opts{stash} || {};
 
   # Safety first...
-  $path =~ s|/$|"/".$plugin->default_file|e;
+  $path =~ s|/$|'/'.$plugin->default_file|e;
   $path =~ s|^/+||;
   $path =~ s|\.\./||g;
   $path =~ s|~||g;
@@ -112,7 +110,7 @@ sub controller {
   if (!$path) { $path = $plugin->default_file; }
   if (-d $pageroot."/$path") {
     if ($path !~ /\/$/) {
-      $path .= "/".$plugin->default_file;
+      $path .= '/'.$plugin->default_file;
     } else {
       return {
         url => "/$path/",
@@ -125,38 +123,38 @@ sub controller {
   if (!defined $stash->{dofiles_executed}) { $stash->{dofiles_executed} = 0; }
 OUTER:
   foreach my $ext (@{$plugin->controller_extension_list}) {
-    foreach my $m ("", "-$method", "-ANY") {
+    foreach my $m ('', "-$method", '-ANY') {
       my $cururl = $path;
       my @path = ();
 
       # This iterates back through the path to find the closest FILE downstream, using the rest of the url as a "path" argument
-      while (!-f $pageroot."/".$cururl.$m.$ext && $cururl =~ s/\/([^\/]*)$//) {
+      while (!-f $pageroot.'/'.$cururl.$m.$ext && $cururl =~ s/\/([^\/]*)$//) {
         if ($1) { unshift(@path, $1); }
       }
 
       # "Do" the file
       if ($cururl) {
         my $result;
-        if (defined $dofiles{$pageroot."/".$cururl.$m.$ext}) {
-          $stash->{dofiles}->{$cururl.$m.$ext} = { origin => "cache", order => $stash->{dofiles_executed}++ };
+        if (defined $dofiles{$pageroot.'/'.$cururl.$m.$ext}) {
+          $stash->{dofiles}->{$cururl.$m.$ext} = { type => 'controller', origin => 'cache', order => $stash->{dofiles_executed}++ };
           if ($plugin->timings) {
             my $start = time();
-            $result = $dofiles{$pageroot."/".$cururl.$m.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
+            $result = $dofiles{$pageroot.'/'.$cururl.$m.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
             $stash->{dofiles}->{$cururl.$m.$ext}->{time} = time() - $start;
           } else {
-            $result = $dofiles{$pageroot."/".$cururl.$m.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
+            $result = $dofiles{$pageroot.'/'.$cururl.$m.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
           }
 
-        } elsif (-f $pageroot."/".$cururl.$m.$ext) {
-          $stash->{dofiles}->{$cururl.$m.$ext} = { origin => "file", order => $stash->{dofiles_executed}++ };
+        } elsif (-f $pageroot.'/'.$cururl.$m.$ext) {
+          $stash->{dofiles}->{$cururl.$m.$ext} = { type => 'controller', origin => 'file', order => $stash->{dofiles_executed}++ };
 
           our $args = { path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env };
 
-          $result = do($pageroot."/".$cururl.$m.$ext);
+          $result = do($pageroot.'/'.$cururl.$m.$ext);
           if ($@ || $!) { $plugin->app->log( error => "Error processing $pageroot / $cururl.$m.$ext: $@ $!\n"); }
-          if (ref $result eq "CODE") {
+          if (ref $result eq 'CODE') {
             $stash->{dofiles}->{$cururl.$m.$ext}->{cached} = 1;
-            $dofiles{$pageroot."/".$cururl.$m.$ext} = $result;
+            $dofiles{$pageroot.'/'.$cururl.$m.$ext} = $result;
             if ($plugin->timings) {
               my $start = time();
               $result = $result->($args);
@@ -167,12 +165,8 @@ OUTER:
           }
         }
 
-        # We need to reassign the stash to the opts hash as the merge will have destroyed the old stash
-        $opts{stash} = $stash;
-
-        if (defined $result && ref $result eq "HASH") {
+        if (defined $result && ref $result eq 'HASH') {
           merge($stash, $result);
-#          $stash = $merger->merge($stash, $result);
           if (defined $result->{url} && !defined $result->{done}) {
             $path = $result->{url};
             next OUTER;
@@ -188,7 +182,7 @@ OUTER:
           }
           # Move on to the next file
 
-        } elsif (ref $result eq "ARRAY") {
+        } elsif (ref $result eq 'ARRAY') {
           $stash->{dofiles}->{$cururl.$m.$ext}->{last} = 1;
           return { content => $result };
 
@@ -223,11 +217,11 @@ sub view {
   my $method = $app->request->method;
 
   my $accept  = HTTP::Accept->new( $app->request->accept )->values();
-  push(@{$accept}, "");
+  push @{$accept}, '';
 
   my $pageroot = $settings->{appdir};
   if ($pageroot !~ /\/$/) {
-    $pageroot .= "/";
+    $pageroot .= '/';
   }
   $pageroot .= $plugin->view_loc;
 
@@ -241,7 +235,7 @@ sub view {
   my $stash = $opts{stash} || {};
 
   # Safety first...
-  $path =~ s|/$|"/".$plugin->default_file|e;
+  $path =~ s|/$|'/'.$plugin->default_file|e;
   $path =~ s|^/+||;
   $path =~ s|\.\./||g;
   $path =~ s|~||g;
@@ -249,7 +243,7 @@ sub view {
   if (!$path) { $path = $plugin->default_file; }
   if (-d $pageroot."/$path") {
     if ($path !~ /\/$/) {
-      $path .= "/".$plugin->default_file;
+      $path .= '/'.$plugin->default_file;
     } else {
       return {
         url => "/$path/",
@@ -262,37 +256,37 @@ OUTER:
   foreach my $ext (@{$plugin->view_extension_list}) {
     foreach my $fmt (@{$accept}) {
       if (defined $acceptext->{$fmt}) {
-        foreach my $m ("", "-$method", "-ANY") {
+        foreach my $m ('', "-$method", '-ANY') {
           my $cururl = $path;
           my @path = ();
           # This iterates back through the path to find the closest FILE downstream, using the rest of the url as a "path" argument
-          while (!-f $pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext && $cururl =~ s/\/([^\/]*)$//) {
+          while (!-f $pageroot.'/'.$cururl.$m.$acceptext->{$fmt}.$ext && $cururl =~ s/\/([^\/]*)$//) {
             if ($1) { unshift(@path, $1); }
           }
 
           # "Do" the file
           if ($cururl) {
             my $result;
-            if (defined $dofiles{$pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext}) {
-              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext} = { origin => "cache", order => $stash->{dofiles_executed}++ };
+            if (defined $dofiles{$pageroot.'/'.$cururl.$m.$acceptext->{$fmt}.$ext}) {
+              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext} = { type => 'view', origin => 'cache', order => $stash->{dofiles_executed}++ };
               if ($plugin->timings) {
                 my $start = time();
-                $result = $dofiles{$pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
+                $result = $dofiles{$pageroot.'/'.$cururl.$m.$acceptext->{$fmt}.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
                 $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext}->{time} = time() - $start;
               } else {
-                $result = $dofiles{$pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
+                $result = $dofiles{$pageroot.'/'.$cururl.$m.$acceptext->{$fmt}.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
               }
 
-            } elsif (-f $pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext) {
-              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext} = { origin => "file", order => $stash->{dofiles_executed}++ };
+            } elsif (-f $pageroot.'/'.$cururl.$m.$acceptext->{$fmt}.$ext) {
+              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext} = { type => 'view', origin => 'file', order => $stash->{dofiles_executed}++ };
 
               our $args = { path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env };
 
-              $result = do($pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext);
+              $result = do($pageroot.'/'.$cururl.$m.$acceptext->{$fmt}.$ext);
               if ($@ || $!) { $plugin->app->log( error => "Error processing $pageroot / $cururl.$m.$acceptext->{$fmt}.$ext: $@ $!\n"); }
-              if (ref $result eq "CODE") {
+              if (ref $result eq 'CODE') {
                 $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext}->{cached} = 1;
-                $dofiles{$pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext} = $result;
+                $dofiles{$pageroot.'/'.$cururl.$m.$acceptext->{$fmt}.$ext} = $result;
                 if ($plugin->timings) {
                   my $start = time();
                   $result = $result->($args);
@@ -303,12 +297,12 @@ OUTER:
               }
             }
 
-            if (defined $result && ref $result eq "HASH") {
+            if (defined $result && ref $result eq 'HASH') {
               $result->{'content-type'} = $acceptext->{$fmt};
               $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext}->{last} = 1;
               return $result;
 
-            } elsif (ref $result eq "ARRAY") {
+            } elsif (ref $result eq 'ARRAY') {
               $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext}->{last} = 1;
               return { 'content-type' => $acceptext->{$fmt}, content => $result };
 
@@ -341,7 +335,7 @@ sub dofile {
   my $method = $app->request->method;
   my $pageroot = $settings->{appdir};
   if ($pageroot !~ /\/$/) {
-    $pageroot .= "/";
+    $pageroot .= '/';
   }
   $pageroot .= $plugin->page_loc;
 
@@ -352,12 +346,10 @@ sub dofile {
   # This can lead to some interesting results if someone doesn't explicitly return undef when they want to fall through to the next file
   # as perl will return the last evaluated value, which would be intepretted as content according to the above rules
 
-  # my $merger = Hash::Merge->new('RIGHT_PRECEDENT');
-
   my $stash = $opts{stash} || {};
 
   # Safety first...
-  $path =~ s|/$|"/".$plugin->default_file|e;
+  $path =~ s|/$|'/'.$plugin->default_file|e;
   $path =~ s|^/+||;
   $path =~ s|\.\./||g;
   $path =~ s|~||g;
@@ -365,7 +357,7 @@ sub dofile {
   if (!$path) { $path = $plugin->default_file; }
   if (-d $pageroot."/$path") {
     if ($path =~ /\/$/) {
-      $path .= "/".$plugin->default_file;
+      $path .= '/'.$plugin->default_file;
     } else {
       return {
         url => "/$path/",
@@ -378,37 +370,37 @@ sub dofile {
   if (!defined $stash->{dofiles_executed}) { $stash->{dofiles_executed} = 0; }
 OUTER:
   foreach my $ext (@{$plugin->extension_list}) {
-    foreach my $m ("", "-$method") {
+    foreach my $m ('', "-$method") {
       my $cururl = $path;
       my @path = ();
 
       # This iterates back through the path to find the closest FILE downstream, using the rest of the url as a "path" argument
-      while (!-f $pageroot."/".$cururl.$m.$ext && $cururl =~ s/\/([^\/]*)$//) {
+      while (!-f $pageroot.'/'.$cururl.$m.$ext && $cururl =~ s/\/([^\/]*)$//) {
         if ($1) { unshift(@path, $1); }
       }
 
       # "Do" the file
       if ($cururl) {
         my $result;
-        if (defined $dofiles{$pageroot."/".$cururl.$m.$ext}) {
-          $stash->{dofiles}->{$cururl.$m.$ext} = { origin => "cache", order => $stash->{dofiles_executed}++ };
-          $result = $dofiles{$pageroot."/".$cururl.$m.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
+        if (defined $dofiles{$pageroot.'/'.$cururl.$m.$ext}) {
+          $stash->{dofiles}->{$cururl.$m.$ext} = { origin => 'cache', order => $stash->{dofiles_executed}++ };
+          $result = $dofiles{$pageroot.'/'.$cururl.$m.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
 
-        } elsif (-f $pageroot."/".$cururl.$m.$ext) {
-          $stash->{dofiles}->{$cururl.$m.$ext} = { origin => "file", order => $stash->{dofiles_executed}++ };
+        } elsif (-f $pageroot.'/'.$cururl.$m.$ext) {
+          $stash->{dofiles}->{$cururl.$m.$ext} = { origin => 'file', order => $stash->{dofiles_executed}++ };
 
           our $args = { path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env };
 
-          $result = do($pageroot."/".$cururl.$m.$ext);
+          $result = do($pageroot.'/'.$cururl.$m.$ext);
           if ($@ || $!) { $plugin->app->log( error => "Error processing $pageroot / $cururl.$m.$ext: $@ $!\n"); }
-          if (ref $result eq "CODE") {
+          if (ref $result eq 'CODE') {
             $stash->{dofiles}->{$cururl.$m.$ext}->{cached} = 1;
-            $dofiles{$pageroot."/".$cururl.$m.$ext} = $result;
+            $dofiles{$pageroot.'/'.$cururl.$m.$ext} = $result;
             $result = $result->($args);
           }
         }
 
-        if (defined $result && ref $result eq "HASH") {
+        if (defined $result && ref $result eq 'HASH') {
           if (defined $result->{url} && !defined $result->{done}) {
             $path = $result->{url};
             next OUTER;
@@ -418,11 +410,10 @@ OUTER:
             return $result;
           } else {
             merge($stash, $result);
-#            $stash = $merger->merge($stash, $result);
           }
           # Move on to the next file
 
-        } elsif (ref $result eq "ARRAY") {
+        } elsif (ref $result eq 'ARRAY') {
           $stash->{dofiles}->{$cururl.$m.$ext}->{last} = 1;
           return { content => $result };
 
@@ -448,11 +439,15 @@ sub layout_pathname {
   my ( $self, $layout ) = @_;
   return $layout;
 }
+
+# Why not use Hash::Merge? I need to merge the result into the stash hashref, not
+# clone or make a new hashref, so that the dofile stats can be accumulated (in
+# $stash->{dofiles})
 sub merge {
   my $src = shift;
   my $dup = shift;
   foreach my $k (keys %{$dup}) {
-    if (ref $dup->{$k} eq "HASH" && $src->{$k} && ref $src->{$k} eq "HASH") {
+    if (ref $dup->{$k} eq 'HASH' && $src->{$k} && ref $src->{$k} eq 'HASH') {
       merge($src->{$k}, $dup->{$k});
     } else {
       $src->{$k} = $dup->{$k};
@@ -734,11 +729,51 @@ This could be used to set the status code for returning to the client
 DoFile may however return pretty much whatever you want to handle in your final
 router code.
 
+=head1 DEBUGGING DONE-FILES
+
+From 0.14 you can see exactly what DoFile is doing, including the
+option to see how long each done-file took to execute so that you may improve
+the performance of your web app.
+
+All you need to do is make sure that you pass an initial "stash" to the
+controller (or view), and DoFiles will store some analysis in a hashref under a
+key called "dofiles".
+
+The key for the hasref is the filename executed. The contents of the hash will
+contain one or more elements giving some information about what's gone on.
+
+    my $stash = {};
+    my $result = controller "some/controller", stash => $stash;
+
+    if (defined $stash->{dofiles}) {
+      my @files = ();
+      foreach my $f (sort { $stash->{dofiles}->{$a}->{order} <=> $stash->{dofiles}->{$b}->{order} } keys %{$stash->{dofiles}}) {
+        my $text = $stash->{dofiles}->{$f}->{order}.": $f";
+        if ($stash->{dofiles}->{$f}->{origin} eq "cache") { $text .= " [FROM CACHE]"; }
+        if ($stash->{dofiles}->{$f}->{origin} eq "file") { $text .= " [FROM FILE]"; }
+        if ($stash->{dofiles}->{$f}->{cached}) { $text .= " [WAS CACHED]"; }
+        if ($stash->{dofiles}->{$f}->{last}) { $text .= " [LAST]"; }
+        if ($stash->{dofiles}->{$f}->{time}) { $text .= " ".int($stash->{dofiles}->{$f}->{time}*1000)."ms"; }
+        # NB: For {time} to be defined you need to add an extra line to your config - see below
+        push @files, $text;
+      }
+      # Do something with your @files.
+    }
+
+To switch on timing of your done-files, in your config.yml
+
+    plugins:
+      DoFile:
+        timings: 1
+
+It's possible in the future the {dofiles} hashref will become an arrayref, as it's
+possible to mess things up by redirecting a page to itself (if for example you need
+to restart processing of passed data).
+
 =head1 EXAMPLES
 
 As noted, what's returned from a DoFile can contain anything. That gives you
 the opportunity to do pretty much whatever you want with what's returned.
-
 
 =head1 AUTHOR
 

--- a/lib/Dancer2/Plugin/DoFile.pm
+++ b/lib/Dancer2/Plugin/DoFile.pm
@@ -106,7 +106,7 @@ sub controller {
 
   if (!$path) { $path = $plugin->default_file; }
   if (-d $pageroot."/$path") {
-    if ($path =~ /\/$/) {
+    if ($path !~ /\/$/) {
       $path .= "/".$plugin->default_file;
     } else {
       return {

--- a/lib/Dancer2/Plugin/DoFile.pm
+++ b/lib/Dancer2/Plugin/DoFile.pm
@@ -748,7 +748,7 @@ contain one or more elements giving some information about what's gone on.
     if (defined $stash->{dofiles}) {
       my @files = ();
       foreach my $f (sort { $stash->{dofiles}->{$a}->{order} <=> $stash->{dofiles}->{$b}->{order} } keys %{$stash->{dofiles}}) {
-        my $text = $stash->{dofiles}->{$f}->{order}.": $f";
+        my $text = $stash->{dofiles}->{$f}->{order}.": $f [".$stash->{dofiles}->{$f}->{type}."]";
         if ($stash->{dofiles}->{$f}->{origin} eq "cache") { $text .= " [FROM CACHE]"; }
         if ($stash->{dofiles}->{$f}->{origin} eq "file") { $text .= " [FROM FILE]"; }
         if ($stash->{dofiles}->{$f}->{cached}) { $text .= " [WAS CACHED]"; }

--- a/lib/Dancer2/Plugin/DoFile.pm
+++ b/lib/Dancer2/Plugin/DoFile.pm
@@ -9,10 +9,29 @@ use Dancer2::Plugin;
 
 use JSON;
 use Hash::Merge;
+use HTTP::Accept;
 
-has page_loc => (
+# Not sure if this is necessary at this point, as the model
+# Should in general not be dynamically loaded...
+#has model_loc => (
+#    is      => 'rw',
+#    default => sub {'dofiles/models'},
+#);
+has controller_loc => (
     is      => 'rw',
-    default => sub {'dofiles/pages'},
+    default => sub {'dofiles/controllers'},
+);
+has controller_extension_list => (
+    is      => 'rw',
+    default => sub { ['.ctl','.do'] }
+);
+has view_loc => (
+    is      => 'rw',
+    default => sub {'dofiles/views'},
+);
+has view_extension_list => (
+    is      => 'rw',
+    default => sub { ['.view','.po'] }
 );
 
 has default_file => (
@@ -20,23 +39,267 @@ has default_file => (
     default => sub {'index'},
 );
 
+# This is old config syntax and should not be used
+# Only preserved as temporary backwards compatibility
+has page_loc => (
+    is      => 'rw',
+    default => sub {'dofiles/pages'},
+);
+# This list will change over time to remove "do" and "po" in favour of "ctl" (controllers) and "view" (views)
 has extension_list => (
     is      => 'rw',
-    default => sub { ['.do', '.view']}
+    default => sub { ['.ctl', '.do', '.po', '.view']}
 );
 
+# Old method
 plugin_keywords 'dofile';
 
+# New methods
+plugin_keywords 'controller';
+plugin_keywords 'view';
+
 my %dofiles;
+my $acceptext = {
+  "" => "",
+  "text/html" => ".html",
+  "application/json" => ".json"
+};
 
 sub BUILD {
     my $self     = shift;
     my $settings = $self->config;
 
     $settings->{$_} and $self->$_( $settings->{$_} )
-      for qw/ page_loc default_file extension_list /;
+      for qw/ page_loc default_file extension_list controller_loc controller_extension_list view_loc view_extension_list /;
 }
 
+sub controller {
+  my $plugin = shift;
+  my $arg = shift;
+  my %opts = @_;
+
+  my $app = $plugin->app;
+  my $settings = $app->settings;
+  my $method = $app->request->method;
+  my $pageroot = $settings->{appdir};
+  if ($pageroot !~ /\/$/) {
+    $pageroot .= "/";
+  }
+  $pageroot .= $plugin->controller_loc;
+
+  my $path = $arg || $app->request->path;
+
+  # If any one of these returns content then we stop processing any more of them
+  # Content is defined as an array ref (it's an Obj2HTML array), a hashref with a "content" element, or a scalar (assumed HTML string - it's not checked!)
+  # This can lead to some interesting results if someone doesn't explicitly return undef when they want to fall through to the next file
+  # as perl will return the last evaluated value, which would be intepretted as content according to the above rules
+
+  my $merger = Hash::Merge->new('RIGHT_PRECEDENT');
+
+  my $stash = $opts{stash} || {};
+
+  # Safety first...
+  $path =~ s|/$|"/".$plugin->default_file|e;
+  $path =~ s|^/+||;
+  $path =~ s|\.\./||g;
+  $path =~ s|~||g;
+
+  if (!$path) { $path = $plugin->default_file; }
+  if (-d $pageroot."/$path") {
+    if ($path =~ /\/$/) {
+      $path .= "/".$plugin->default_file;
+    } else {
+      return {
+        url => "/$path/",
+        redirect => 1,
+        done => 1
+      };
+    }
+  }
+
+  if (!defined $stash->{dofiles_executed}) { $stash->{dofiles_executed} = 0; }
+OUTER:
+  foreach my $ext (@{$plugin->controller_extension_list}) {
+    foreach my $m ("", "-$method", "-ANY") {
+      my $cururl = $path;
+      my @path = ();
+
+      # This iterates back through the path to find the closest FILE downstream, using the rest of the url as a "path" argument
+      while (!-f $pageroot."/".$cururl.$m.$ext && $cururl =~ s/\/([^\/]*)$//) {
+        if ($1) { unshift(@path, $1); }
+      }
+
+      # "Do" the file
+      if ($cururl) {
+        my $result;
+        if (defined $dofiles{$pageroot."/".$cururl.$m.$ext}) {
+          $stash->{dofiles}->{$cururl.$m.$ext} = { origin => "cache", order => $stash->{dofiles_executed}++ };
+          $result = $dofiles{$pageroot."/".$cururl.$m.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
+
+        } elsif (-f $pageroot."/".$cururl.$m.$ext) {
+          $stash->{dofiles}->{$cururl.$m.$ext} = { origin => "file", order => $stash->{dofiles_executed}++ };
+
+          our $args = { path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env };
+
+          $result = do($pageroot."/".$cururl.$m.$ext);
+          if ($@ || $!) { $plugin->app->log( error => "Error processing $pageroot / $cururl.$m.$ext: $@ $!\n"); }
+          if (ref $result eq "CODE") {
+            $stash->{dofiles}->{$cururl.$m.$ext}->{cached} = 1;
+            $dofiles{$pageroot."/".$cururl.$m.$ext} = $result;
+            $result = $result->($args);
+          }
+        }
+
+        # We need to reassign the stash to the opts hash as the merge will have destroyed the old stash
+        $opts{stash} = $stash;
+
+        if (defined $result && ref $result eq "HASH") {
+          if (defined $result->{url} && !defined $result->{done}) {
+            $path = $result->{url};
+            next OUTER;
+          }
+          if (defined $result->{view} && $result->{done}) {
+            $stash->{dofiles}->{$cururl.$m.$ext}->{last} = 1;
+            $stash->{'controller_result'} = $result;
+            return $plugin->view($result->{view}, path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env );
+
+          } elsif (defined $result->{content} || $result->{url} || $result->{done}) {
+            $stash->{dofiles}->{$cururl.$m.$ext}->{last} = 1;
+            return $result;
+          } else {
+            $stash = $merger->merge($stash, $result);
+          }
+          # Move on to the next file
+
+        } elsif (ref $result eq "ARRAY") {
+          $stash->{dofiles}->{$cururl.$m.$ext}->{last} = 1;
+          return { content => $result };
+
+        } elsif (!ref $result && $result) {
+          # do we assume this is HTML? Or a file to use in templating? Who knows!
+          $stash->{dofiles}->{$cururl.$m.$ext}->{last} = 1;
+          return { content => $result };
+
+        }
+      }
+    }
+  }
+
+  # If we got here we didn't find a controller. We should fail over to see if it's just a view on its own (effectively this module or the route acts as the controller)
+  return $plugin->view($arg, %opts);
+}
+
+sub view {
+  my $plugin = shift;
+  my $arg = shift;
+  my %opts = @_;
+
+  my $app = $plugin->app;
+  my $settings = $app->settings;
+  my $method = $app->request->method;
+
+  my $accept  = HTTP::Accept->new( $app->request->accept )->values();
+  push(@{$accept}, "");
+
+  my $pageroot = $settings->{appdir};
+  if ($pageroot !~ /\/$/) {
+    $pageroot .= "/";
+  }
+  $pageroot .= $plugin->view_loc;
+
+  my $path = $arg || $app->request->path;
+
+  # If any one of these returns content then we stop processing any more of them
+  # Content is defined as an array ref (it's an Obj2HTML array), a hashref with a "content" element, or a scalar (assumed HTML string - it's not checked!)
+  # This can lead to some interesting results if someone doesn't explicitly return undef when they want to fall through to the next file
+  # as perl will return the last evaluated value, which would be intepretted as content according to the above rules
+
+  my $merger = Hash::Merge->new('RIGHT_PRECEDENT');
+
+  my $stash = $opts{stash} || {};
+
+  # Safety first...
+  $path =~ s|/$|"/".$plugin->default_file|e;
+  $path =~ s|^/+||;
+  $path =~ s|\.\./||g;
+  $path =~ s|~||g;
+
+  if (!$path) { $path = $plugin->default_file; }
+  if (-d $pageroot."/$path") {
+    if ($path =~ /\/$/) {
+      $path .= "/".$plugin->default_file;
+    } else {
+      return {
+        url => "/$path/",
+        redirect => 1,
+        done => 1
+      };
+    }
+  }
+OUTER:
+  foreach my $ext (@{$plugin->view_extension_list}) {
+    foreach my $fmt (@{$accept}) {
+      if (defined $acceptext->{$fmt}) {
+        foreach my $m ("", "-$method", "-ANY") {
+          my $cururl = $path;
+          my @path = ();
+          # This iterates back through the path to find the closest FILE downstream, using the rest of the url as a "path" argument
+          while (!-f $pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext && $cururl =~ s/\/([^\/]*)$//) {
+            if ($1) { unshift(@path, $1); }
+          }
+
+          # "Do" the file
+          if ($cururl) {
+            my $result;
+            if (defined $dofiles{$pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext}) {
+              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext} = { origin => "cache", order => $stash->{dofiles_executed}++ };
+              $result = $dofiles{$pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext}->({path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env});
+
+            } elsif (-f $pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext) {
+              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext} = { origin => "file", order => $stash->{dofiles_executed}++ };
+
+              our $args = { path => \@path, this_url => $cururl, dofile_plugin => $plugin, stash => $stash, env => $app->request->env };
+
+              $result = do($pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext);
+              if ($@ || $!) { $plugin->app->log( error => "Error processing $pageroot / $cururl.$m.$acceptext->{$fmt}.$ext: $@ $!\n"); }
+              if (ref $result eq "CODE") {
+                $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext}->{cached} = 1;
+                $dofiles{$pageroot."/".$cururl.$m.$acceptext->{$fmt}.$ext} = $result;
+                $result = $result->($args);
+              }
+            }
+
+            # We need to reassign the stash to the opts hash as the merge will have destroyed the old stash
+            $opts{stash} = $stash;
+
+            if (defined $result && ref $result eq "HASH") {
+              $result->{'content-type'} = $acceptext->{$fmt};
+              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext}->{last} = 1;
+              return $result;
+
+            } elsif (ref $result eq "ARRAY") {
+              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext}->{last} = 1;
+              return { 'content-type' => $acceptext->{$fmt}, content => $result };
+
+            } elsif (!ref $result && $result) {
+              # do we assume this is HTML? Or a file to use in templating? Who knows!
+              $stash->{dofiles}->{$cururl.$m.$acceptext->{$fmt}.$ext}->{last} = 1;
+              return { 'content-type' => $acceptext->{$fmt}, content => $result };
+
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # If we got here we didn't find a do file that returned some content
+  return { status => 404 };
+
+}
+
+
+# Backward compatibility
 sub dofile {
   my $plugin = shift;
   my $arg = shift;


### PR DESCRIPTION
As mentioned in the Perl Weekly as well, I think it can be really valuable to enable Continuous Integration (CI) and improve testing on all the CPAN modules where the author is interested in it. Having CI configured will provide fast feedback to the author(s) and will reduce the chances of releasing a module that only works on the computer of the developer. Reducing the manual work-load for the CPAN Tester. Currently GitHub Actions is the most natural CI system for GitHub-based projects. That's why I am sending this PR.

I've enabled several versions of Perl on 3 different platforms. Except 5.36 on Windows as it does not seem to exist.



I have written several blog posts and recorded videos on the subject. You can find them here: https://perlmaven.com/os
If you need further help with the CI system, check out my posts https://perlmaven.com/ci and **feel free to ask me**.

If you'd like to support my efforts there are several ways to do so https://szabgab.com/support.html

